### PR TITLE
Add get olympian stats endpoint with passing test

### DIFF
--- a/models/olympian.js
+++ b/models/olympian.js
@@ -12,6 +12,32 @@ class Olympian {
   static oldest() {
     return database('olympic').orderBy('age', 'desc').select(['name', 'team', 'age', 'sport', database.raw(`(case when olympic.medal is null then 0 end) as total_medals_won`)]).limit(1)
   };
+
+  total_competing_olympians() {
+    return database('olympic').distinct('name').select('name')
+  }
+
+  male_olympians_count() {
+    return database('olympic').where('sex', 'M').avg('weight')
+  }
+
+  female_olympians_count() {
+    return database('olympic').where('sex', 'F').avg('weight')
+  }
+
+  average_age() {
+    return database('olympic').avg('age')
+  }
+
+  static stats() {
+    let olympian = new Olympian
+    return [
+      olympian.total_competing_olympians().then(res => res.length),
+      olympian.male_olympians_count().then(res => Number(res[0].avg)),
+      olympian.female_olympians_count().then(res => Number(res[0].avg)),
+      olympian.average_age().then(res => Number(res[0].avg))
+    ]
+  }
 }
 
  module.exports = Olympian;

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -33,4 +33,25 @@ router.get('/olympians', (request, response) => {
     }
 });
 
+router.get('/olympian_stats', async (request, response) => {
+  let temp = await Promise.all(olympian.stats())
+    .then((data) => {
+      let result = {
+                    "olympian_stats": {
+                      "total_competing_olympians": data[0],
+                      "average_weight": {
+                        "unit": "kg",
+                        "male_olympians": Number(data[1].toFixed(1)),
+                        "female_olympians": Number(data[2].toFixed(1))
+                      },
+                      "average_age": Number(data[3].toFixed(1))
+                    }
+                  }
+      return response.status(200).json(result);
+    })
+    .catch((error) => {
+      return response.status(500).json({ error });
+    });
+});
+
 module.exports = router;

--- a/tests/olympians.spec.js
+++ b/tests/olympians.spec.js
@@ -165,4 +165,34 @@ describe('test get all olympians', () => {
     });
   });
 
+  describe('test GET olympian stats', () => {
+    it('happy path', async () => {
+      const res = await request(app).get("/api/v1/olympian_stats");
+
+      expect(res.statusCode).toBe(200);
+
+      expect(res.body['olympian_stats']).toHaveProperty('total_competing_olympians');
+      expect(res.body['olympian_stats'].total_competing_olympians).toEqual(4);
+
+      expect(res.body['olympian_stats']).toHaveProperty('average_weight');
+      expect(res.body['olympian_stats'].average_weight).toHaveProperty('unit');
+      expect(res.body['olympian_stats'].average_weight.unit).toEqual('kg');
+
+      expect(res.body['olympian_stats'].average_weight).toHaveProperty('male_olympians');
+      expect(res.body['olympian_stats'].average_weight.male_olympians).toEqual(64);
+
+      expect(res.body['olympian_stats'].average_weight).toHaveProperty('female_olympians');
+      expect(res.body['olympian_stats'].average_weight.female_olympians).toEqual(77.7);
+
+      expect(res.body['olympian_stats']).toHaveProperty('average_age');
+      expect(res.body['olympian_stats'].average_age).toEqual(30);
+    });
+
+    it('sad path', async () => {
+      const res = await request(app).get("/api/v1/olympianstats");
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.message).toEqual('Not Found');
+    });
+  });
 });


### PR DESCRIPTION
- This endpoint returns a response that 'almost' matches the expected output. The data structure looks similar but not the actual value. For instance:
  - There are 3485 rows in total
  - Expected value: 3120
  - My attempt: 2850

- Needs to clarify:
  - `total_competing_olympians` ??
 
