### PR TITLE
Add get all events endpoint with passing test

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
 var olympiansRouter = require('./routes/api/v1/olympians');
+var eventsRouter = require('./routes/api/v1/events');
 
 app.use(logger('dev'));
 app.use(express.json());
@@ -16,6 +17,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/api/v1', olympiansRouter);
+app.use('/api/v1/events', eventsRouter);
 app.use((req, res, next)=>{
   res.status(404).send({message:"Not Found"});
 });

--- a/models/events.js
+++ b/models/events.js
@@ -1,0 +1,12 @@
+const database = require('../config.js');
+
+class Events {
+  static all() {
+    return database('olympic')
+      .select('sport', database.raw('ARRAY_AGG(DISTINCT olympic.event) as events'))
+      .groupBy('sport')
+      .orderBy('sport')
+  }
+}
+
+module.exports = Events;

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const events = require('../../../models/events.js');
+
+
+router.get('/', (request, response) => {
+  events.all()
+    .then((data) => {
+      let result = { "events": data }
+      return response.status(200).json(result);
+    })
+    .catch((error) => {
+      return response.status(500).json({ error });
+    });
+})
+
+module.exports = router;

--- a/tests/events.spec.js
+++ b/tests/events.spec.js
@@ -1,0 +1,96 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('test get all events', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table olympic cascade');
+
+    let aanei = {
+      "name": "Andreea Aanei",
+      "sex": "F",
+      "age": 22,
+      "height": 170,
+      "weight": 125,
+      "team": "Romania",
+      "games": "2016 Summer",
+      "sport": "Weightlifting",
+      "event": "Weightlifting Women's Super-Heavyweight",
+      "medal": null
+    };
+
+    let sanjun = {
+      "name": "Nstor Abad Sanjun",
+      "sex": "M",
+      "age": 23,
+      "height": 167,
+      "weight": 64,
+      "team": "Spain",
+      "games": "2016 Summer",
+      "sport": "Gymnastics",
+      "event": "Gymnastics Men's Individual All-Around",
+      "medal": null
+    };
+
+    let dascl = {
+      "name": "Ana Iulia Dascl",
+      "sex": "F",
+      "age": 13,
+      "height": 183,
+      "weight": 60,
+      "team": "Romania",
+      "games": "2016 Summer",
+      "sport": "Swimming",
+      "event": "Swimming Women's 100 metres Freestyle",
+      "medal": null
+    };
+
+    let brougham = {
+      "name": "Julie Brougham",
+      "sex": "F",
+      "age": 62,
+      "height": 157,
+      "weight": 48,
+      "team": "New Zealand",
+      "games": "2016 Summer",
+      "sport": "Equestrianism",
+      "event": "Equestrianism Mixed Dressage, Individual",
+      "medal": null
+    };
+
+    await database('olympic').insert(aanei, 'id');
+    await database('olympic').insert(sanjun, 'id');
+    await database('olympic').insert(dascl, 'id');
+    await database('olympic').insert(brougham, 'id');
+  });
+
+  afterEach(() => {
+    database.raw('truncate table olympic cascade');
+  });
+
+  describe('test events GET', () => {
+    it('happy path', async () => {
+      const res = await request(app).get("/api/v1/events");
+
+      expect(res.statusCode).toBe(200);
+
+      expect(res.body['events'].length).toEqual(4)
+      expect(res.body['events'][0]).toHaveProperty('sport');
+      expect(res.body['events'][0].sport).toEqual('Equestrianism');
+
+      expect(res.body['events'][0]).toHaveProperty('events');
+      expect(res.body['events'][0].events).toEqual(["Equestrianism Mixed Dressage, Individual"]);
+    });
+
+    it('sad path', async () => {
+      const res = await request(app).get("/api/v1/event");
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.message).toEqual('Not Found');
+    });
+  });
+});


### PR DESCRIPTION
The biggest challenge in building this endpoint was 
figuring out how to return an array of unique values (aka, `event`)
grouped by another column value (aka, `sport`).

One solution was using array aggregate function in `database.raw('ARRAY_AGG(DISTINCT column))`.