### PR TITLE
Get medalists by eventid endpoint

### DIFF
--- a/db/migrations/20200113202254_events.js
+++ b/db/migrations/20200113202254_events.js
@@ -1,0 +1,18 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.createTable('events', function(table) {
+      table.increments('id').primary();
+      table.string('event');
+      table.string('event_id');
+      table.string('medal');
+      table.integer('olympian_id').references('id').inTable('events').notNull().onDelete('cascade');
+    })
+  ])
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.dropTable('olympic')
+  ])
+};

--- a/models/events.js
+++ b/models/events.js
@@ -7,6 +7,19 @@ class Events {
       .groupBy('sport')
       .orderBy('sport')
   }
+
+  static findMedalistsById(id) {
+    return database('olympic')
+      .select(
+        'events.event',
+        database.raw('json_agg(json_build_object(\'name\', olympic.name, \'team\', olympic.team, \'age\', olympic.age, \'medal\', olympic.medal)) as medalists')
+      )
+      .join('events', 'olympic.id', 'events.olympian_id')
+      .where('events.event_id', id)
+      .groupBy('events.event')
+      .whereNot('events.medal', null)
+      .first()
+  }
 }
 
 module.exports = Events;

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -14,4 +14,19 @@ router.get('/', (request, response) => {
     });
 })
 
+router.get('/:id/medalists', (request, response) => {
+  var id = request.params.id
+  // total number of unique events = 79
+  if (id < 1 || id > 79) {
+    return response.status(404).json({'message': 'id is out of range. Valid range of id is 0 < id < 80'});
+  }
+  events.findMedalistsById(id)
+    .then((result) => {
+      return response.status(200).json(result);
+    })
+    .catch((error) => {
+      return response.status(500).json({ error });
+    });
+})
+
 module.exports = router;


### PR DESCRIPTION
### Challenge 1
The last endpoint had an `:id` parameter, which seemed to suggest that there were recurring events, and they would share the same event_id.

So I created a new table called `events`, with columns including: 
  - `event`
  - `event_id`
  - `medal` 
  - `olympian_id`

Note that `event_id` is not primary key of the table, as it would assign auto-incremented integer. Rather, I had to run a psql command that would assign rank to the rows of the result set, like so:

1. Connect to psql. Then choose the current table.
```
$ psql
username=#  \c koroibos_olympic_development
koroibos_olympic_development=#
```

2. Then run the following command.
```
UPDATE events
    SET    event_id = r.rnk
    FROM (SELECT event, DENSE_RANK() OVER ( ORDER BY event) as rnk
          FROM events
         ) r
    WHERE events.event = r.event;
```

Then, the table will be updated as below:

<img width="836" alt="Screen Shot 2020-01-13 at 9 32 13 PM" src="https://user-images.githubusercontent.com/24424825/72314447-44542100-364c-11ea-9f36-9c6a7cc9e6ba.png">

This way, same events can be grouped by their id's.


### Challenge 2
This endpoint required a response that contained an array of json objects. Using `json_agg( )` within select statement came in handy.


### Challenge 3
To avoid error related to foreign key constraints during testing:
make sure that seeding is done sequentially (see `events.spec.js`). 

#### References
- https://www.eversql.com/rank-vs-dense_rank-vs-row_number-in-postgresql/
- https://www.sqltutorial.org/sql-window-functions/sql-rank/
- https://stackoverflow.com/questions/35723675/update-postgresql-table-using-rank
- https://dba.stackexchange.com/questions/69655/select-columns-inside-json-agg